### PR TITLE
Update streamlit to 1.23.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-streamlit==1.11.1
+streamlit==1.23.1
 plotly==5.1.0
 protobuf~=3.19.0


### PR DESCRIPTION
Fixes Altair 5 compatibility.

Closes #1 